### PR TITLE
makemake - block-news (prompt variation)

### DIFF
--- a/src/components/BlockNews/BlockNews.vue
+++ b/src/components/BlockNews/BlockNews.vue
@@ -4,7 +4,7 @@
             <span class="more">More</span>
         </wp-image>
         <div class="block-text">
-            <p class="prompt">Next</p>
+            <span v-if="hasPrompt" class="prompt">Next</span>
             <div class="meta">
                 <time class="date" v-html="formattedDate" />
                 <h3 class="title" v-html="title" />
@@ -156,21 +156,20 @@ export default {
     &.has-prompt {
         align-items: normal;
 
-        .excerpt,
-        .categories {
-            display: none;
-        }
-        .prompt {
-            display: block;
-            margin-bottom: auto;
-        }
         .block-text {
             display: flex;
             flex-direction: column;
-            justify-content: center;
+            justify-content: space-between;
         }
-        .meta {
-            margin-bottom: auto;
+        .categories {
+            display: none;
+        }
+        .excerpt {
+            margin-bottom: 30px;
+        }
+        .prompt {
+            display: block;
+            margin-top: 30px;
         }
     }
 

--- a/src/components/BlockNews/BlockNews.vue
+++ b/src/components/BlockNews/BlockNews.vue
@@ -1,17 +1,20 @@
 <template>
-    <nuxt-link class="block-news" :to="to">
+    <nuxt-link :class="classes" :to="to">
         <wp-image class="block-image" :image="image">
             <span class="more">More</span>
         </wp-image>
         <div class="block-text">
-            <time class="date" v-html="formattedDate" />
-            <h3 class="title" v-html="title" />
-            <p class="excerpt" v-html="stripTags(excerpt)" />
-            <div v-if="categories" class="categories">
-                <span
-                    v-for="(category, i) in categories"
-                    v-html="category.name + comma(i)"
-                />
+            <p class="prompt">Next</p>
+            <div class="meta">
+                <time class="date" v-html="formattedDate" />
+                <h3 class="title" v-html="title" />
+                <p class="excerpt" v-html="stripTags(excerpt)" />
+                <div v-if="categories" class="categories">
+                    <span
+                        v-for="(category, i) in categories"
+                        v-html="category.name + comma(i)"
+                    />
+                </div>
             </div>
         </div>
     </nuxt-link>
@@ -54,9 +57,16 @@ export default {
         categories: {
             type: Array,
             default: () => []
+        },
+        hasPrompt: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {
+        classes() {
+            return ["block-news", { "has-prompt": this.hasPrompt }]
+        },
         formattedDate() {
             return formatDate(this.date)
         }
@@ -117,6 +127,9 @@ export default {
         margin: 15px 0;
         font-size: 14px;
     }
+    .date {
+        font-size: 14px;
+    }
     .more {
         position: absolute;
         bottom: 0;
@@ -132,6 +145,33 @@ export default {
         background-color: var(--color-company);
         color: var(--color-black);
         opacity: 0;
+    }
+    .prompt {
+        display: none;
+        margin: 0;
+        font-size: 25px;
+        font-weight: 300;
+    }
+    // Promt styles
+    &.has-prompt {
+        align-items: normal;
+
+        .excerpt,
+        .categories {
+            display: none;
+        }
+        .prompt {
+            display: block;
+            margin-bottom: auto;
+        }
+        .block-text {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+        }
+        .meta {
+            margin-bottom: auto;
+        }
     }
 
     // Hovers
@@ -156,6 +196,9 @@ export default {
         .block-text {
             margin-top: 15px;
             padding: 0;
+        }
+        &.has-prompt {
+            align-items: center;
         }
     }
 }

--- a/src/components/BlockNews/BlockPost.stories.js
+++ b/src/components/BlockNews/BlockPost.stories.js
@@ -21,3 +21,21 @@ export const BlockNewsDefault = () => ({
                 :categories="api.categories"
                 />`
 })
+
+export const BlockNewsPrompt = () => ({
+    components: { BlockNews },
+    data() {
+        return {
+            api: API
+        }
+    },
+    template: `<block-news
+                :to="api.page.uri"
+                :date="api.page.date"
+                :title="api.page.title"
+                :excerpt="api.page.excerpt"
+                :image="api.page.featuredImage"
+                :categories="api.categories"
+                :hasPrompt="true"
+                />`
+})


### PR DESCRIPTION
Components included in this PR are:

1. {https://github.com/funkhaus/factory/issues/10#issuecomment-652603666} - {block-news} - With prompt variation

## Notes

The request was for the "prompt" prop to be a string, but I'm assuming this will be determined by hasNextPage(?) and therefore made it a boolean. If my thinking was wrong, all the same checks could be made on string / no string, so the change would be easy. Let me know if it needs to be updated.
