### PR TITLE
Doomsday - FooterSocials

### DIFF
--- a/src/components/FooterSocials/FooterSocials.stories.js
+++ b/src/components/FooterSocials/FooterSocials.stories.js
@@ -1,0 +1,38 @@
+import FooterSocials from "./FooterSocials"
+import API from "@/static/db.json"
+
+const Items = API.menuItems.nodes.slice(0, 3)
+
+export default {
+    title: "@dchiamp / FooterSocials"
+}
+
+export const Default = () => ({
+    components: { FooterSocials },
+    data() {
+        return {
+            items: Items
+        }
+    },
+    template: `<footer-socials :items="items" />`
+})
+
+export const BlackTheme = () => ({
+    components: { FooterSocials },
+    data() {
+        return {
+            items: Items
+        }
+    },
+    template: `<footer-socials :items="items" color-theme="black" />`
+})
+
+export const OrangeTheme = () => ({
+    components: { FooterSocials },
+    data() {
+        return {
+            items: Items
+        }
+    },
+    template: `<footer-socials :items="items" color-theme="orange" />`
+})

--- a/src/components/FooterSocials/FooterSocials.stories.js
+++ b/src/components/FooterSocials/FooterSocials.stories.js
@@ -16,23 +16,3 @@ export const Default = () => ({
     },
     template: `<footer-socials :items="items" />`
 })
-
-export const BlackTheme = () => ({
-    components: { FooterSocials },
-    data() {
-        return {
-            items: Items
-        }
-    },
-    template: `<footer-socials :items="items" color-theme="black" />`
-})
-
-export const OrangeTheme = () => ({
-    components: { FooterSocials },
-    data() {
-        return {
-            items: Items
-        }
-    },
-    template: `<footer-socials :items="items" color-theme="orange" />`
-})

--- a/src/components/FooterSocials/FooterSocials.vue
+++ b/src/components/FooterSocials/FooterSocials.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-    <section v-if="items.length" :class="`footer-socials theme-${colorTheme}`">
+    <section v-if="items.length" class="footer-socials">
         <wp-menu :items="items" />
     </section>
 </template>
@@ -18,10 +18,6 @@ export default {
         items: {
             type: Array,
             default: () => []
-        },
-        colorTheme: {
-            type: String,
-            default: "pink"
         }
     }
 }
@@ -36,7 +32,7 @@ export default {
     height: 255px;
     padding: 50px;
     box-sizing: border-box;
-    background-color: var(--color-pink);
+    background-color: var(--color-footer-background);
 
     /deep/ .wp-menu {
         display: block;
@@ -44,7 +40,6 @@ export default {
         margin: 0;
         list-style: none;
         text-align: center;
-        color: var(--color-yellow);
         text-transform: uppercase;
         font-size: 50px;
         flex-direction: column;
@@ -55,21 +50,10 @@ export default {
             display: inline-flex;
             font-family: var(--font-secondary);
             font-weight: 500;
+            color: var(--color-footer-text);
+            -webkit-text-stroke: 1px var(--color-footer-text);
             transition: color 0.4s ease-in-out,
-                -webkit-text-stroke 0.4s ease-in-out 0.2s;
-        }
-    }
-
-    &.theme-orange {
-        background-color: var(--color-orange);
-        /deep/ .wp-menu {
-            color: var(--color-yellow);
-        }
-    }
-    &.theme-black {
-        background-color: var(--color-black);
-        /deep/ .wp-menu {
-            color: var(--color-red);
+                -webkit-text-stroke 0.4s ease-in-out 0.1s;
         }
     }
 
@@ -80,20 +64,6 @@ export default {
             -webkit-text-stroke: 1px var(--color-black);
             transition: color 0.4s ease-in-out,
                 -webkit-text-stroke 0.4s ease-in-out;
-        }
-        &.theme-black {
-            /deep/ .wp-menu a:hover,
-            /deep/ .wp-menu .mock-nuxt-link:hover {
-                color: var(--color-black);
-                -webkit-text-stroke: 1px var(--color-red);
-            }
-        }
-        &.theme-orange {
-            /deep/ .wp-menu a:hover,
-            /deep/ .wp-menu .mock-nuxt-link:hover {
-                color: var(--color-orange);
-                -webkit-text-stroke: 1px var(--color-black);
-            }
         }
     }
 

--- a/src/components/FooterSocials/FooterSocials.vue
+++ b/src/components/FooterSocials/FooterSocials.vue
@@ -46,14 +46,15 @@ export default {
         text-align: center;
         color: var(--color-yellow);
         text-transform: uppercase;
-        font-size: 40px;
+        font-size: 50px;
         flex-direction: column;
 
         a,
         .mock-nuxt-link {
             // DELETE .mock-nuxt-link when adding to project (will be an a tag)
             display: inline-flex;
-            font-weight: 900;
+            font-family: var(--font-secondary);
+            font-weight: 500;
             transition: color 0.4s ease-in-out,
                 -webkit-text-stroke 0.4s ease-in-out 0.2s;
         }
@@ -102,7 +103,7 @@ export default {
         height: auto;
 
         /deep/ .wp-menu {
-            font-size: 20px;
+            font-size: 25px;
         }
     }
 }

--- a/src/components/FooterSocials/FooterSocials.vue
+++ b/src/components/FooterSocials/FooterSocials.vue
@@ -1,0 +1,109 @@
+<template lang="html">
+    <section v-if="items.length" :class="`footer-socials theme-${colorTheme}`">
+        <wp-menu :items="items" />
+    </section>
+</template>
+
+<script>
+//  Components
+import WpMenu from "@/components/global/WpMenu"
+import WpMenuItem from "@/components/global/WpMenuItem"
+
+export default {
+    components: {
+        WpMenu,
+        WpMenuItem
+    },
+    props: {
+        items: {
+            type: Array,
+            default: () => []
+        },
+        colorTheme: {
+            type: String,
+            default: "pink"
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.footer-socials {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 255px;
+    padding: 50px;
+    box-sizing: border-box;
+    background-color: var(--color-pink);
+
+    /deep/ .wp-menu {
+        display: block;
+        padding: 0;
+        margin: 0;
+        list-style: none;
+        text-align: center;
+        color: var(--color-yellow);
+        text-transform: uppercase;
+        font-size: 40px;
+        flex-direction: column;
+
+        a,
+        .mock-nuxt-link {
+            // DELETE .mock-nuxt-link when adding to project (will be an a tag)
+            display: inline-flex;
+            font-weight: 900;
+            transition: color 0.4s ease-in-out,
+                -webkit-text-stroke 0.4s ease-in-out 0.2s;
+        }
+    }
+
+    &.theme-orange {
+        background-color: var(--color-orange);
+        /deep/ .wp-menu {
+            color: var(--color-yellow);
+        }
+    }
+    &.theme-black {
+        background-color: var(--color-black);
+        /deep/ .wp-menu {
+            color: var(--color-red);
+        }
+    }
+
+    @media #{$has-hover} {
+        /deep/ .wp-menu a:hover,
+        /deep/ .wp-menu .mock-nuxt-link:hover {
+            color: var(--color-pink);
+            -webkit-text-stroke: 1px var(--color-black);
+            transition: color 0.4s ease-in-out,
+                -webkit-text-stroke 0.4s ease-in-out;
+        }
+        &.theme-black {
+            /deep/ .wp-menu a:hover,
+            /deep/ .wp-menu .mock-nuxt-link:hover {
+                color: var(--color-black);
+                -webkit-text-stroke: 1px var(--color-red);
+            }
+        }
+        &.theme-orange {
+            /deep/ .wp-menu a:hover,
+            /deep/ .wp-menu .mock-nuxt-link:hover {
+                color: var(--color-orange);
+                -webkit-text-stroke: 1px var(--color-black);
+            }
+        }
+    }
+
+    // Breakpoints
+    @media #{$lt-phone} {
+        padding: 20px;
+        height: auto;
+
+        /deep/ .wp-menu {
+            font-size: 20px;
+        }
+    }
+}
+</style>

--- a/src/components/global/WpMenu.vue
+++ b/src/components/global/WpMenu.vue
@@ -1,0 +1,83 @@
+<template>
+    <ul :class="classes">
+        <slot name="before" />
+
+        <wp-menu-item
+            v-for="(item, i) in menuItems"
+            :key="i"
+            class="menu-item"
+            :item="item"
+            @menu-interacted="menuInteracted"
+        />
+
+        <slot name="after" />
+    </ul>
+</template>
+
+<script>
+// Helpers
+import _kebabCase from "lodash/kebabCase"
+import _upperCase from "lodash/upperCase"
+import _get from "lodash/get"
+
+// GQL
+// import MENU_BY_LOCATION from "~/gql/queries/MenuByLocation"
+
+// Components
+import WpMenuItem from "@/components/global/WpMenuItem"
+
+export default {
+    components: {
+        WpMenuItem
+    },
+    props: {
+        location: {
+            type: String,
+            default: ""
+        },
+        items: {
+            type: Array,
+            default: () => []
+        }
+    },
+    async fetch() {
+        // Don't fetch if WordPress menu items provided, use them.
+        if (this.items.length) {
+            this.menuItems = this.items
+            return;
+        }
+
+        // Make location name upper case with undersocres instead of spaces
+        const locationName = _upperCase(this.location).replace(/ /g, "_")
+        try {
+            let response = await this.$apollo
+                .query({
+                    query: MENU_BY_LOCATION,
+                    variables: {
+                        location: locationName
+                    }
+                })
+                .then(({ data }) => data)
+
+            this.menuItems = _get(response, "menuItems.nodes", [])
+        } catch (error) {
+            console.log("Fetch error in <wp-menu>: ", error)
+        }
+    },
+    data() {
+        return {
+            menuItems: this.items
+        }
+    },
+    computed: {
+        classes() {
+            return ["wp-menu", `location-${_kebabCase(this.location)}`]
+        }
+    },
+    methods: {
+        menuInteracted(event) {
+            this.$emit("menu-interacted", event)
+        }
+    }
+}
+</script>

--- a/src/components/global/WpMenuItem.vue
+++ b/src/components/global/WpMenuItem.vue
@@ -1,0 +1,94 @@
+<template>
+    <li :class="classes">
+        <a
+            v-if="!isRelative || isMailTo"
+            target="_blank"
+            :href="item.url"
+            @click="menuInteracted"
+            v-html="item.label"
+        />
+
+        <nuxt-link
+            v-if="isRelative && !isHash"
+            :to="relativeUrl"
+            @click.native="menuInteracted"
+            v-html="item.label"
+        />
+
+        <span v-if="isHash" v-html="item.label" />
+
+        <ul v-if="hasSubMenu" class="sub-menu">
+            <wp-menu-item
+                v-for="(subItem, i) in getChildren"
+                :key="`sub-${i}`"
+                class="menu-item sub-menu-item"
+                :item="subItem"
+                @menu-interacted="menuInteracted"
+            />
+        </ul>
+    </li>
+</template>
+
+<script>
+import _get from "lodash/get"
+
+// Components
+import NuxtLink from "@/components/global/NuxtLink"
+
+export default {
+    components: {
+        NuxtLink
+    },
+    props: {
+        item: {
+            type: Object,
+            default: () => {}
+        }
+    },
+    computed: {
+        classes() {
+            return [
+                "wp-menu-item menu-item",
+                {
+                    "is-realtive": this.isRelative
+                },
+                { "has-sub-menu": this.hasSubMenu },
+                { "is-disabled": this.isHash }
+            ]
+        },
+        getChildren() {
+            return _get(this, "item.childItems.nodes", [])
+        },
+        hasSubMenu() {
+            return this.getChildren.length
+        },
+        isRelative() {
+            return this.item.target !== "_blank" && !this.isMailTo
+        },
+        isHash() {
+            return this.item.label == "#"
+        },
+        isMailTo() {
+            return this.item.url.includes("mailto:")
+        },
+        relativeUrl() {
+            let url = this.item.url
+            // Replace all these things
+            const replaceThese = [
+                _get(this, "$store.state.siteMeta.frontendUrl", ""),
+                _get(this, "$store.state.siteMeta.backendUrl", ""),
+                _get(this, "$store.state.siteMeta.host", "")
+            ]
+            replaceThese.forEach(element => {
+                url = url.replace(element, "")
+            });
+            return url
+        }
+    },
+    methods: {
+        menuInteracted(event) {
+            this.$emit("menu-interacted", event)
+        }
+    }
+}
+</script>


### PR DESCRIPTION
Components included in this PR are:

1. FooterSocials
1. WpMenu
1. WpMenuItem

## Notes

Got exact font details from Dave.

I added a prop for `color-theme` to make things easier.  Seems there are at least 3 colors: pink, black, and orange.

When this component is added to the project, you should delete `.mock-nuxt-link` class in scss. When using real WpMenuItems from WPGQL it will be an external link and use an anchor tag.

The hover-off effect feels off to me. I want to add a delay to `webkit-text-stroke` on hover off, but can't seem to target it. I tried using `webkit-text-stroke-width` and `-webkit-text-stroke-color` specifically but still couldn't make it work even though the spec says you should be able to apply transitions to `-webkit-text-stroke-color`.  
